### PR TITLE
Fixes import in Class-based Views example code

### DIFF
--- a/docs/user/views.rst
+++ b/docs/user/views.rst
@@ -11,7 +11,7 @@ request would be routed to the class's ``post()`` method::
 
     from pyramid.response import Response
 
-    from restful_framework.views import APIView
+    from pyramid_restful.views import APIView
 
     from .models import User
 


### PR DESCRIPTION
This is the first import statement that folks see when they look through the quick-start guide, and is currently improperly formatted.